### PR TITLE
Add baptism service page and link from homepage

### DIFF
--- a/bapteme.html
+++ b/bapteme.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Baptême - Révérend Constant</title>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <div class="header-content">
+            <img src="logo.png" alt="Logo" class="logo">
+            <h1>Révérend Constant</h1>
+        </div>
+        <div class="collar-design"></div>
+    </header>
+
+    <main>
+        <div class="presentation">
+            <h2>Présentation</h2>
+            <p>Le baptême est une étape spirituelle fondamentale, marquant l'entrée dans la communauté chrétienne. C'est l'ouverture d'une porte vers un chemin que le baptisé choisira ou non de suivre, dans son libre arbitre, mais qui lui est offert pour avancer dans la direction du Christ.</p>
+            
+            <p>Les cérémonies se déroulent exclusivement dans mon presbytère, situé à 10 minutes de Waterloo, dans un cadre intime et spirituel.</p>
+            
+            <p>Selon les règles œcuméniques actuelles, les baptêmes protestants effectués selon un rite conforme au rite catholique (comme je le pratique) sont pleinement reconnus par l'Église catholique, et réciproquement.</p>
+        </div>
+
+        <div class="image-gallery">
+            <img src="bapteme1.jpg" alt="Baptême 1">
+            <img src="bapteme2.jpg" alt="Baptême 2">
+            <img src="bapteme3.jpg" alt="Baptême 3">
+        </div>
+
+        <div class="organisation">
+            <h2>Organisation du Baptême</h2>
+            <ul>
+                <li>Envoi préalable d'informations sur la signification du baptême</li>
+                <li>Accueil des personnes le jour J</li>
+                <li>Service liturgique dirigé par le Révérend</li>
+                <li>Baptême au nom du Père, du Fils et du Saint-Esprit</li>
+                <li>Inscription au Livre des Actes</li>
+                <li>Remise du certificat de baptême</li>
+            </ul>
+        </div>
+
+        <div class="tarifs">
+            <h2>Tarifs</h2>
+            <p>50€ par personne (paiement à la réservation)</p>
+            <p><em>Note : Si vous êtes dans le besoin, n'hésitez pas à me contacter pour un baptême gratuit.</em></p>
+        </div>
+
+        <div class="paypal-button">
+            <style>.pp-6D668VX27S8WJ{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
+            <form action="https://www.paypal.com/ncp/payment/6D668VX27S8WJ" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
+              <input class="pp-6D668VX27S8WJ" type="submit" value="Payer 50€" />
+              <img src=https://www.paypalobjects.com/images/Debit_Credit_APM.svg alt="cards" />
+              <section> Optimisé par <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
+            </form>
+        </div>
+    </main>
+
+    <footer>
+        <div class="footer-links">
+            <a href="index.html">Accueil</a>
+            <a href="agenda.html">Agenda</a>
+            <a href="dons.html">Faire un don</a>
+            <a href="contact.html">Contact</a>
+        </div>
+        <p>&copy; 2025 Révérend Constant. Tous droits réservés.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new baptism service page and links it from the homepage. Changes include:

- Created new `bapteme.html` page with:
  - Service presentation and description
  - Image gallery section
  - Ceremony organization details
  - Pricing information (50€ per person)
  - PayPal payment integration
- Updated `index.html` to include baptism service in the services section

The baptism page follows the same structure and styling as the existing marriage page while providing specific content for baptism ceremonies.